### PR TITLE
Bug fix: Double completion call when cache is full.

### DIFF
--- a/IAPManager.swift
+++ b/IAPManager.swift
@@ -60,12 +60,12 @@ public class IAPManager: NSObject {
         
         if remainingIds.count == 0 {
             completion(loadedProducts, nil)
+        } else {
+            let request = SKProductsRequest(productIdentifiers: Set(remainingIds))
+            request.delegate = self
+            loadProductsRequests.append(LoadProductsRequestInfo(request: request, completion: completion))
+            request.start()
         }
-        
-        let request = SKProductsRequest(productIdentifiers: Set(remainingIds))
-        request.delegate = self
-        loadProductsRequests.append(LoadProductsRequestInfo(request: request, completion: completion))
-        request.start()
     }
     
     public func purchaseProduct(productId: String, completion: @escaping PurchaseProductCompletionBlock) {


### PR DESCRIPTION
Hello, I've just started using this library and it's really easy to use, thanks for that!

I noticed an issue when viewing a page a second time that it would call the completion handler twice causing unexpected behavior.

I tested this change in my code base and it's no longer causing the issue. Let me know if you have any concerns about this change.

Thanks :)